### PR TITLE
fix search results

### DIFF
--- a/Static/css/site.css
+++ b/Static/css/site.css
@@ -81,6 +81,10 @@
         -webkit-overflow-scrolling: touch;
     }
 
+li.nav-item a.nav-link:focus {
+    outline: 2px solid #4382DF;
+}
+
 .btn-bd-primary {
     --bd-violet-bg: #712cf9;
     --bd-violet-rgb: 112.520718, 44.062154, 249.437846;

--- a/Static/index.html
+++ b/Static/index.html
@@ -128,6 +128,8 @@
         <div id="cookie-banner"></div>
     </div>
 
+    <div id="resultsCount" aria-live="polite" style="opacity: 0; width: 0.1px; height: 0.1px;"></div>
+
     <main class="flex-fill" id="main" tabindex="200">
 
         <div id="demoMap" tabindex="201" class="container-fluid p-0 m-0 w-100 h-100" role="application"></div>

--- a/Static/js/site.js
+++ b/Static/js/site.js
@@ -314,6 +314,7 @@ function search() {
 
         //Create the HTML for the results list.
         var html = "";
+        var count = 0;
         for (var i = 0; i < data.features.length; i++) {
             var r = data.features[i];
 
@@ -351,8 +352,10 @@ function search() {
             var tbid = 230 + i;
 
             html += `<a href="#" tabindex="${tbid}" class="list-group-item list-group-item-action d-flex gap-3 py-3" onclick="itemClicked('${r.id}')" onmouseover="itemHovered('${r.id}')"><svg class="flex-shrink-0" width="2.0em" height="2.0em"><use xlink:href="#${icon}" /></svg><div class="d-flex gap-2 w-100 justify-content-between"><div><h6 class="mb-0">${name}</h6><p class="mb-0 opacity-75">${r.properties.address.freeformAddress}</p></div><small class="text-nowrap">${dist} km</small></div></a>`;
+            count++;
         }
         resultsPanel.innerHTML = html;
+        document.getElementById('resultsCount').innerHTML = count > 0 ? `<p>${count} results are available, use tab key to navigate.</p>`: '<p>Sorry, no results matching your search criteria were found.</p>';
 
         datasource.add(data);
 

--- a/Static/js/site.js
+++ b/Static/js/site.js
@@ -355,7 +355,7 @@ function search() {
             count++;
         }
         resultsPanel.innerHTML = html;
-        document.getElementById('resultsCount').innerHTML = count > 0 ? `<p>${count} results are available, use tab key to navigate.</p>`: '<p>Sorry, no results matching your search criteria were found.</p>';
+        document.getElementById('resultsCount').innerHTML = count > 0 ? `<p>${count} result${count === 1 ? ' is' : 's are'} available. Use the tab key to navigate.</p>`: '<p>Sorry, we couldn't find any results that match your search criteria.</p>';
 
         datasource.add(data);
 


### PR DESCRIPTION
- Issue:
Screen reader is not announcing the information about search suggestions appearing on giving input in search fields.
- Fix:
Use aria-live="polite" attribute to automatically announce the number of search results to screen readers
(Contents in div is not detectable if div set to `display: none` or `visibility: hidden`)
![screenreader_demosite](https://github.com/user-attachments/assets/1a2bce7c-f6c5-4b81-9cbb-4a5a4cb8cafa)
