### PR TITLE
fix: luminosity ratio of the focus indicator

### DIFF
--- a/Static/css/site.css
+++ b/Static/css/site.css
@@ -81,6 +81,10 @@
         -webkit-overflow-scrolling: touch;
     }
 
+li.nav-item a.nav-link:focus {
+    outline: 2px solid #4382DF;
+}
+
 .btn-bd-primary {
     --bd-violet-bg: #712cf9;
     --bd-violet-rgb: 112.520718, 44.062154, 249.437846;


### PR DESCRIPTION
Luminosity ratio of the focus indicator with respect to its background of the controls in header section is now greater than the required ratio 3:1.
![image](https://github.com/user-attachments/assets/166eb420-a631-4232-8d02-bf3375d13bda)
