### PR TITLE
fix: focus on entire results panel

### DIFF
--- a/Static/index.html
+++ b/Static/index.html
@@ -413,7 +413,7 @@
                     </select>
                 </div>
             </div>
-            <div id="results-panel" tabindex="217" class="list-group"></div>
+            <div id="results-panel" class="list-group"></div>
         </div>
 
     </main>


### PR DESCRIPTION
- Issue: Focus is landing on entire search results and announcing entire information.
- Result:
![result_focus](https://github.com/user-attachments/assets/f61cbc6b-de02-4f6f-b3d0-8994d3076be7)