### PR TITLE
fix: popup for small screen

### DIFF
--- a/Static/css/site.css
+++ b/Static/css/site.css
@@ -19,8 +19,17 @@
 }
 
 @media only screen and (max-width: 640px) {
+    #demoMap {
+        height: 80vh !important;
+    }
+
     #search {
-        display: none;
+        position: static;
+        max-width: 100vw;
+    }
+
+    #results-panel {
+        max-height: 320px;
     }
 
     footer {


### PR DESCRIPTION
- Issue:
At 320*256 reflow setting (scale the browser up to 150%-250%), Pop up is not appearing.
- Result:
Users can scroll down to see the pop up and the search results at screen width <= 640px.
When browser scaled to over 150%, the map takes up the screen, causing users to accidentally scroll on it instead of the page. Therefore, the map height is set to a smaller value to make scrolling easier for users.
![popup_smallscreen](https://github.com/user-attachments/assets/339a30dd-e882-4202-bcfb-3e7515de889f)
